### PR TITLE
Update Mistweaver.lua

### DIFF
--- a/Specialization/Mistweaver.lua
+++ b/Specialization/Mistweaver.lua
@@ -52,7 +52,7 @@ function Monk:Mistweaver()
     local talents = fd.talents;
     local targets = fd.targets;
     local gcd = fd.gcd;
-    local targetHp = MaxDps:TargetPercentHealth() * 100;
+    local targetHp = UnitHealth('target')
     local health = UnitHealth('player');
     local healthMax = UnitHealthMax('player');
     local healthPercent = ( health / healthMax ) * 100;


### PR DESCRIPTION
change targethp for touch of death calculation

this should fix touch of death being a requirement before any other skills in rotation